### PR TITLE
Feat: Add link to a working NuxtJs App

### DIFF
--- a/Supported_frameworks.md
+++ b/Supported_frameworks.md
@@ -4,6 +4,7 @@ The following is a list of frameworks that we have actively tested and are suppo
 
 - [Next.js](https://stackblitz.com/fork/nextjs)
 - [NestJS](https://stackblitz.com/fork/nestjs-starter)
+- [NuxtJS](https://stackblitz.com/edit/nuxtjs)
 
 ## Add support for a framework
 


### PR DESCRIPTION
I've just made a nuxt js app with stackblitz.
It can also be used as a starter template 😉
I added NuxtJs to the list of supported frameworks.